### PR TITLE
Export IPaginationInterface, IPageInfo type definitions in package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export {
   LimitOffset,
   RelayForward,
   NoPagination,
+  IPageInfo,
+  IPaginationAdapter,
 } from "./config/pagination-adapters"
 
 export {


### PR DESCRIPTION
This exports the type definitions for IPaginationAdapter and IPageInfo in the main package so they can be used when building custom pagination adapters. 